### PR TITLE
fix: add workspace path aliases

### DIFF
--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -9,6 +9,18 @@
     "paths": {
       "@/*": [
         "./*"
+      ],
+      "@repo/types": [
+        "../../packages/types/src"
+      ],
+      "@repo/types/*": [
+        "../../packages/types/src/*"
+      ],
+      "@repo/db": [
+        "../../packages/db/src"
+      ],
+      "@repo/db/*": [
+        "../../packages/db/src/*"
       ]
     }
   },


### PR DESCRIPTION
## Summary
- map `@repo/types` and `@repo/db` to their source directories in frontend `tsconfig.json`

## Testing
- `npx turbo run build --filter=frontend` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a570ca3764832e9324dbb4e6815484