### PR TITLE
fix(frontend): resolve shared package imports

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-switch": "^1.2.5",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@repo/types": "*",
+    "@repo/db": "*",
     "@svgr/webpack": "^8.1.0",
     "@tanstack/react-query": "^5.83.0",
     "@types/diff": "^7.0.2",
@@ -60,7 +61,6 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@repo/db": "*",
     "@repo/eslint-config": "^0.0.0",
     "@repo/typescript-config": "*",
     "@shikijs/monaco": "^3.8.1",

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -7,18 +7,15 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"],
+      "@repo/types": ["../../packages/types/src"],
+      "@repo/types/*": ["../../packages/types/src/*"],
+      "@repo/db": ["../../packages/db/src/client"],
+      "@repo/db/*": ["../../packages/db/src/*"],
+      "@repo/command-security": ["../../packages/command-security/src"],
+      "@repo/command-security/*": ["../../packages/command-security/src/*"]
     }
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-switch": "^1.2.5",
         "@radix-ui/react-tooltip": "^1.2.7",
+        "@repo/db": "*",
         "@repo/types": "*",
         "@svgr/webpack": "^8.1.0",
         "@tanstack/react-query": "^5.83.0",
@@ -73,7 +74,6 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
-        "@repo/db": "*",
         "@repo/eslint-config": "^0.0.0",
         "@repo/typescript-config": "*",
         "@shikijs/monaco": "^3.8.1",


### PR DESCRIPTION
## Summary
- include `@repo/db` as a runtime dependency so the frontend can resolve the database package during production builds

## Testing
- `npx turbo run build --filter=frontend` *(fails: `next/font` couldn't fetch Geist Mono from Google Fonts)*
- `cd apps/frontend && npx tsc --noEmit` *(fails: missing type declarations for `material-icon-theme` icons)*

------
https://chatgpt.com/codex/tasks/task_e_68a570ca3764832e9324dbb4e6815484