### PR TITLE
fix(frontend): resolve shared package imports

### DIFF
--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
   /* config options here */
@@ -40,6 +41,17 @@ const nextConfig: NextConfig = {
 
     // Modify the file loader rule to ignore *.svg, since we have it handled now.
     fileLoaderRule.exclude = /\.svg$/i;
+
+    // Ensure workspace packages resolve from source during builds
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      "@repo/types": path.resolve(__dirname, "../../packages/types/src"),
+      "@repo/db": path.resolve(__dirname, "../../packages/db/src/client"),
+      "@repo/command-security": path.resolve(
+        __dirname,
+        "../../packages/command-security/src"
+      ),
+    };
 
     return config;
   },

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-switch": "^1.2.5",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@repo/types": "*",
+    "@repo/db": "*",
     "@svgr/webpack": "^8.1.0",
     "@tanstack/react-query": "^5.83.0",
     "@types/diff": "^7.0.2",
@@ -60,7 +61,6 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@repo/db": "*",
     "@repo/eslint-config": "^0.0.0",
     "@repo/typescript-config": "*",
     "@shikijs/monaco": "^3.8.1",

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -7,18 +7,15 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"],
+      "@repo/types": ["../../packages/types/src"],
+      "@repo/types/*": ["../../packages/types/src/*"],
+      "@repo/db": ["../../packages/db/src/client"],
+      "@repo/db/*": ["../../packages/db/src/*"],
+      "@repo/command-security": ["../../packages/command-security/src"],
+      "@repo/command-security/*": ["../../packages/command-security/src/*"]
     }
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }

--- a/apps/frontend/types/material-icon-theme.d.ts
+++ b/apps/frontend/types/material-icon-theme.d.ts
@@ -1,0 +1,5 @@
+declare module "material-icon-theme/icons/*.svg" {
+  import { FC, SVGProps } from "react";
+  const Icon: FC<SVGProps<SVGSVGElement>>;
+  export default Icon;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-switch": "^1.2.5",
         "@radix-ui/react-tooltip": "^1.2.7",
+        "@repo/db": "*",
         "@repo/types": "*",
         "@svgr/webpack": "^8.1.0",
         "@tanstack/react-query": "^5.83.0",
@@ -73,7 +74,6 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
-        "@repo/db": "*",
         "@repo/eslint-config": "^0.0.0",
         "@repo/typescript-config": "*",
         "@shikijs/monaco": "^3.8.1",


### PR DESCRIPTION
## Summary
- include `@repo/types` and `@repo/db` as runtime dependencies so the frontend can resolve shared workspace packages during production builds
- add module declarations for `material-icon-theme` icons to satisfy TypeScript
- map shared `@repo/*` packages to their source directories via webpack aliases

## Testing
- `cd apps/frontend && npx tsc --noEmit`
- `npx turbo run build --filter=frontend` *(fails: `next/font` error: Failed to fetch `Geist` and `Geist Mono` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a570ca3764832e9324dbb4e6815484

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Improved build configuration to reliably resolve internal workspace packages, reducing module resolution issues across environments.
  * Adjusted dependency classification to ensure required packages are included in production builds.
  * Added TypeScript path aliases for smoother imports and better editor support.
  * Enabled typing for SVG icons as React components, improving icon integration and consistency.

* Refactor
  * Streamlined configuration formatting for clarity without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->